### PR TITLE
Phase 1.3: Set Up Authentication Triggers

### DIFF
--- a/supabase/migrations/003_auth_triggers.sql
+++ b/supabase/migrations/003_auth_triggers.sql
@@ -1,0 +1,30 @@
+-- 003_auth_triggers.sql
+-- Set up authentication triggers for automatic profile creation
+
+-- Function to handle new user registration
+create or replace function handle_new_user()
+returns trigger as $$
+begin
+  -- Insert into profiles table with metadata from auth
+  insert into public.profiles (id, full_name, role)
+  values (
+    new.id,
+    coalesce(
+      new.raw_user_meta_data->>'full_name',
+      new.raw_user_meta_data->>'name',
+      'Unknown User'
+    ),
+    coalesce(
+      new.raw_user_meta_data->>'role',
+      'assistant'  -- Default role
+    )
+  );
+  
+  return new;
+end;
+$$ language plpgsql security definer;
+
+-- Create trigger to fire on new user creation
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function handle_new_user();


### PR DESCRIPTION
## Summary
Set up automatic profile creation triggers when new users register through Supabase Auth.

## Changes Made
- ✅ Created `handle_new_user()` function that automatically creates profile entries
- ✅ Extracts `full_name` from `raw_user_meta_data` with fallbacks:
  - First tries `full_name` field
  - Falls back to `name` field  
  - Defaults to 'Unknown User' if neither exists
- ✅ Sets default role to 'assistant' if not specified in metadata
- ✅ Created `on_auth_user_created` trigger that fires after new user insertion
- ✅ Applied migration successfully to Supabase

## Technical Details
- Function uses `SECURITY DEFINER` for proper permissions
- Trigger fires `AFTER INSERT` on `auth.users` table
- Uses `coalesce()` for robust metadata extraction
- Handles edge cases where metadata might be missing

## Testing
- Verified trigger creation in database
- Confirmed function exists with proper security settings
- Ready for testing with actual user registration

Fixes #4